### PR TITLE
Fix set volume on android

### DIFF
--- a/android/src/main/kotlin/com/kurenai7968/volume_controller/VolumeControllerPlugin.kt
+++ b/android/src/main/kotlin/com/kurenai7968/volume_controller/VolumeControllerPlugin.kt
@@ -38,6 +38,7 @@ class VolumeControllerPlugin: FlutterPlugin, MethodCallHandler {
         var volume:Double = call.argument("volume")!!
         var showSystemUI:Boolean = call.argument("showSystemUI")!!
         volumeObserver.setVolumeByPercentage(volume, showSystemUI)
+        result.success(null)
       }
       "getVolume" -> result.success(volumeObserver.getVolume())
     }


### PR DESCRIPTION
This PR adds a null result for set volume calls in order to allow async/await functionality.